### PR TITLE
モバイルでのレイアウト崩れを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ dist-ssr
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+**/.playwright-mcp

--- a/src/components/FormatTabs.tsx
+++ b/src/components/FormatTabs.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { FormatType } from '../types';
-import { 
-  FaFileAlt, 
-  FaFileCode, 
-  FaFileExcel, 
-  FaCode, 
-  FaTable 
+import {
+  FaFileAlt,
+  FaFileCode,
+  FaFileExcel,
+  FaCode,
+  FaTable
 } from 'react-icons/fa';
 
 interface FormatTabsProps {
@@ -17,6 +17,38 @@ const FormatTabs: React.FC<FormatTabsProps> = ({
   selectedFormat,
   onFormatChange,
 }) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [showRightGradient, setShowRightGradient] = useState(true);
+  const [showLeftGradient, setShowLeftGradient] = useState(false);
+
+  useEffect(() => {
+    const checkScroll = () => {
+      if (scrollRef.current) {
+        const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
+        const hasScrollableContent = scrollWidth > clientWidth;
+        const isNotAtEnd = scrollLeft < scrollWidth - clientWidth - 1;
+        const isNotAtStart = scrollLeft > 1;
+        setShowRightGradient(hasScrollableContent && isNotAtEnd);
+        setShowLeftGradient(hasScrollableContent && isNotAtStart);
+      }
+    };
+
+    const el = scrollRef.current;
+    if (el) {
+      // Initial check with a small delay to ensure content is rendered
+      setTimeout(checkScroll, 0);
+      el.addEventListener('scroll', checkScroll);
+      window.addEventListener('resize', checkScroll);
+    }
+
+    return () => {
+      if (el) {
+        el.removeEventListener('scroll', checkScroll);
+        window.removeEventListener('resize', checkScroll);
+      }
+    };
+  }, []);
+
   // Format icons
   const formatIcons: Record<FormatType, React.ReactNode> = {
     csv: <FaFileExcel />,
@@ -36,21 +68,32 @@ const FormatTabs: React.FC<FormatTabsProps> = ({
   };
 
   return (
-    <div className="flex border border-slate-200 rounded-md overflow-hidden">
-      {Object.entries(formatNames).map(([format, name]) => (
-        <button
-          key={format}
-          className={`flex-1 py-2 px-3 flex items-center justify-center space-x-2 transition-colors text-sm ${
-            selectedFormat === format
-              ? 'bg-blue-100 text-blue-700'
-              : 'text-slate-600 hover:bg-slate-50 bg-white'
-          }`}
-          onClick={() => onFormatChange(format as FormatType)}
-        >
-          <span>{formatIcons[format as FormatType]}</span>
-          <span>{name}</span>
-        </button>
-      ))}
+    <div className="relative">
+      <div
+        ref={scrollRef}
+        className="flex border border-slate-200 rounded-md overflow-x-auto scrollbar-hide"
+      >
+        {Object.entries(formatNames).map(([format, name]) => (
+          <button
+            key={format}
+            className={`sm:flex-1 flex-shrink-0 py-2 px-3 flex items-center justify-center space-x-2 transition-colors text-sm whitespace-nowrap ${
+              selectedFormat === format
+                ? 'bg-blue-100 text-blue-700'
+                : 'text-slate-600 hover:bg-slate-50 bg-white'
+            }`}
+            onClick={() => onFormatChange(format as FormatType)}
+          >
+            <span>{formatIcons[format as FormatType]}</span>
+            <span>{name}</span>
+          </button>
+        ))}
+      </div>
+      {showLeftGradient && (
+        <div className="sm:hidden absolute left-0 top-0 bottom-0 w-8 bg-gradient-to-r from-white to-transparent pointer-events-none rounded-l-md" />
+      )}
+      {showRightGradient && (
+        <div className="sm:hidden absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-white to-transparent pointer-events-none rounded-r-md" />
+      )}
     </div>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ const Header: React.FC = () => {
   return (
     <>
       <header className="p-4">
-        <div className="container mx-auto max-w-5xl flex justify-between items-center">
+        <div className="container mx-auto max-w-5xl flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 sm:gap-0">
           <div className="flex flex-col">
             <h1 className="text-3xl font-bold text-slate-500">TableConv</h1>
             <span className="text-sm text-slate-500">
@@ -24,7 +24,7 @@ const Header: React.FC = () => {
               </button>
             </span>
           </div>
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center space-x-4 self-end sm:self-auto">
             <LanguageSelector />
             <a
               href="https://github.com/kumanorihjkl/table_conv"

--- a/src/components/InputFormatTabs.tsx
+++ b/src/components/InputFormatTabs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { FormatType } from '../types';
 import {
   FaFileAlt,
@@ -18,6 +18,38 @@ const InputFormatTabs: React.FC<InputFormatTabsProps> = ({
   detectedFormat,
   onFormatChange,
 }) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [showRightGradient, setShowRightGradient] = useState(true);
+  const [showLeftGradient, setShowLeftGradient] = useState(false);
+
+  useEffect(() => {
+    const checkScroll = () => {
+      if (scrollRef.current) {
+        const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
+        const hasScrollableContent = scrollWidth > clientWidth;
+        const isNotAtEnd = scrollLeft < scrollWidth - clientWidth - 1;
+        const isNotAtStart = scrollLeft > 1;
+        setShowRightGradient(hasScrollableContent && isNotAtEnd);
+        setShowLeftGradient(hasScrollableContent && isNotAtStart);
+      }
+    };
+
+    const el = scrollRef.current;
+    if (el) {
+      // Initial check with a small delay to ensure content is rendered
+      setTimeout(checkScroll, 0);
+      el.addEventListener('scroll', checkScroll);
+      window.addEventListener('resize', checkScroll);
+    }
+
+    return () => {
+      if (el) {
+        el.removeEventListener('scroll', checkScroll);
+        window.removeEventListener('resize', checkScroll);
+      }
+    };
+  }, []);
+
   // Input formats (exclude TeX which is output-only)
   const inputFormats: FormatType[] = ['csv', 'json', 'markdown', 'html'];
 
@@ -40,26 +72,37 @@ const InputFormatTabs: React.FC<InputFormatTabsProps> = ({
   };
 
   return (
-    <div className="flex border border-slate-200 rounded-md overflow-hidden">
-      {inputFormats.map((format) => (
-        <button
-          key={format}
-          className={`flex-1 py-2 px-3 flex items-center justify-center space-x-2 transition-colors text-sm ${
-            selectedFormat === format
-              ? 'bg-blue-100 text-blue-700'
-              : 'text-slate-600 hover:bg-slate-50 bg-white'
-          }`}
-          onClick={() => onFormatChange(format)}
-        >
-          <span>{formatIcons[format]}</span>
-          <span>{formatNames[format]}</span>
-          {detectedFormat === format && (
-            <span className="ml-1 text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded">
-              検出
-            </span>
-          )}
-        </button>
-      ))}
+    <div className="relative">
+      <div
+        ref={scrollRef}
+        className="flex border border-slate-200 rounded-md overflow-x-auto scrollbar-hide"
+      >
+        {inputFormats.map((format) => (
+          <button
+            key={format}
+            className={`sm:flex-1 flex-shrink-0 py-2 px-3 flex items-center justify-center space-x-2 transition-colors text-sm whitespace-nowrap ${
+              selectedFormat === format
+                ? 'bg-blue-100 text-blue-700'
+                : 'text-slate-600 hover:bg-slate-50 bg-white'
+            }`}
+            onClick={() => onFormatChange(format)}
+          >
+            <span>{formatIcons[format]}</span>
+            <span>{formatNames[format]}</span>
+            {detectedFormat === format && (
+              <span className="ml-1 text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded">
+                検出
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+      {showLeftGradient && (
+        <div className="sm:hidden absolute left-0 top-0 bottom-0 w-8 bg-gradient-to-r from-white to-transparent pointer-events-none rounded-l-md" />
+      )}
+      {showRightGradient && (
+        <div className="sm:hidden absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-white to-transparent pointer-events-none rounded-r-md" />
+      )}
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,13 @@ body {
 }
 
 /* Custom styles can be added below */
+
+/* Hide scrollbar for horizontal scroll areas */
+.scrollbar-hide {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;  /* Chrome, Safari, Opera */
+}


### PR DESCRIPTION
fix: #19 


# モバイルレイアウト改善

## 概要

モバイル表示でのレイアウト崩れを修正し、UXを改善しました。

---

## 変更内容

### 1. フォーマットタブの横スクロール対応

**対象ファイル:**
- `src/components/InputFormatTabs.tsx`
- `src/components/FormatTabs.tsx`
- `src/index.css`

**問題:**
モバイル表示時に入力形式/出力形式のタブが右側で切れてしまい、一部のタブ（HTML、TeX）が見えなくなっていた。

**解決策:**
- タブコンテナを横スクロール可能に変更
- モバイルではタブが縮小しないように `flex-shrink-0` を適用
- デスクトップでは従来通り均等配置（`sm:flex-1`）

**追加機能 - スクロールインジケーター:**
- スクロール可能であることを示すグラデーションを左右に表示
- 左端にいる時は右側のみグラデーション表示
- 中間位置では左右両方にグラデーション表示
- 右端にいる時は左側のみグラデーション表示
- スクロールバーは非表示（`scrollbar-hide` クラス）

```css
/* src/index.css に追加 */
.scrollbar-hide {
  -ms-overflow-style: none;
  scrollbar-width: none;
}
.scrollbar-hide::-webkit-scrollbar {
  display: none;
}
```

---

### 2. ヘッダーのレスポンシブ対応

**対象ファイル:**
- `src/components/Header.tsx`

**問題:**
モバイル表示時に説明文と言語選択・GitHubアイコンが横並びで雑然とした印象を与えていた。

**解決策:**
- モバイル: 縦並びレイアウト（説明文の下に言語選択・GitHubアイコン）
- デスクトップ: 従来通り横並びレイアウト

```tsx
// Before
<div className="... flex justify-between items-center">

// After
<div className="... flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 sm:gap-0">
```

---

### 3. 言語選択・GitHubアイコンの右寄せ

**対象ファイル:**
- `src/components/Header.tsx`

**問題:**
モバイル表示時に言語選択とGitHubアイコンが左寄せになっていた。

**解決策:**
- モバイルでは右寄せ（`self-end`）
- デスクトップでは自動配置（`sm:self-auto`）

```tsx
// Before
<div className="flex items-center space-x-4">

// After
<div className="flex items-center space-x-4 self-end sm:self-auto">
```

---

## 動作確認

### フォーマットタブ

| 解像度 | レイアウト |
|--------|----------|
| モバイル (430x932) | 横スクロール可能、グラデーションインジケーター表示 |
| PC (1920x1080) | 全タブ均等表示、グラデーションなし |

### ヘッダー

| 解像度 | レイアウト |
|--------|----------|
| モバイル (430x932) | 縦並び、言語選択・GitHubアイコンは右寄せ |
| PC (1920x1080) | 横並び（左: 説明文、右: 言語選択・GitHubアイコン） |

---

## 技術詳細

### スクロール検知ロジック

```typescript
const checkScroll = () => {
  if (scrollRef.current) {
    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
    const hasScrollableContent = scrollWidth > clientWidth;
    const isNotAtEnd = scrollLeft < scrollWidth - clientWidth - 1;
    const isNotAtStart = scrollLeft > 1;
    setShowRightGradient(hasScrollableContent && isNotAtEnd);
    setShowLeftGradient(hasScrollableContent && isNotAtStart);
  }
};
```

- `hasScrollableContent`: スクロール可能なコンテンツがあるか
- `isNotAtEnd`: 右端に達していないか
- `isNotAtStart`: 左端から離れているか
