### PR TITLE
fix BASE_URL and x-default to resolve Google redirect warning

### DIFF
--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-const BASE_URL = 'https://table-conv.pages.dev';
+const BASE_URL = 'https://table-conv.awef.me';
 
 const SEOHead: React.FC = () => {
   const { t, i18n } = useTranslation();
@@ -91,11 +91,11 @@ function updateHreflangLinks(_currentLang: string) {
     head.appendChild(link);
   });
 
-  // Add x-default (points to root which redirects)
+  // Add x-default (points to English as default)
   const defaultLink = document.createElement('link');
   defaultLink.rel = 'alternate';
   defaultLink.hreflang = 'x-default';
-  defaultLink.href = `${BASE_URL}/`;
+  defaultLink.href = `${BASE_URL}/en/`;
   head.appendChild(defaultLink);
 }
 


### PR DESCRIPTION
## Summary
- Change `BASE_URL` in `SEOHead.tsx` from `https://table-conv.pages.dev` to `https://table-conv.awef.me` to match `index.html` and `sitemap.xml`
- Change `x-default` hreflang from `/` to `/en/` to avoid redirect detection by Google

## Background
Google Search Consoleで「リダイレクトがあります」としてページがインデックスされない問題の修正。

原因：
1. `SEOHead.tsx`のBASE_URLが`pages.dev`を指していたが、`index.html`と`sitemap.xml`は`awef.me`を指していた
2. `x-default`が`/`（リダイレクトするページ）を指していた

## Test plan
- [ ] デプロイ後、Google Search Consoleで該当URLの再クロールをリクエスト
- [ ] hreflangタグが正しく出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)